### PR TITLE
feat: Add Github action to publish build folder on gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,22 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          cname: internetmadeinbcn.org
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: ${{ github.event.head_commit.message }}

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-internetmadeinbcn.org


### PR DESCRIPTION
## WHAT 

Publish automatically the contents of the `public` directory on the `gh-pages` branch. For now we're still building the site locally with `make build` and committing the changes to the `public` directory, but this should be done eventually by the Github action automatically.